### PR TITLE
CLIENT-789: add name and password reset on Restore page

### DIFF
--- a/src/modules/restore/controllers/RestoreCtrl.js
+++ b/src/modules/restore/controllers/RestoreCtrl.js
@@ -6,6 +6,7 @@
      * @param $scope
      * @param {User} user
      * @param {app.utils} utils
+     * @param modalManager
      * @return {RestoreCtrl}
      */
     const controller = function (Base, $scope, user, utils, modalManager) {
@@ -19,11 +20,11 @@
                 /**
                  * @type {string}
                  */
-                this.address = null;
+                this.address = '';
                 /**
                  * @type {string}
                  */
-                this.seed = null;
+                this.seed = '';
                 /**
                  * @type {string}
                  */
@@ -31,11 +32,11 @@
                 /**
                  * @type {string}
                  */
-                this.encryptedSeed = null;
+                this.encryptedSeed = '';
                 /**
                  * @type {string}
                  */
-                this.password = null;
+                this.password = '';
 
                 this.observe('seed', this._onChangeSeed);
                 this.observeOnce('seedForm', () => {
@@ -61,6 +62,11 @@
                     encryptedSeed,
                     publicKey
                 }, true);
+            }
+
+            resetNameAndPassword() {
+                this.name = '';
+                this.password = '';
             }
 
             /**

--- a/src/modules/restore/templates/restore.html
+++ b/src/modules/restore/templates/restore.html
@@ -54,7 +54,7 @@
             <div class="headline-1 text-center" w-i18n="passwordForm.title"></div>
             <div class="body-2 text-center margin-5">
                 <span class="disabled-600" w-i18n="passwordForm.description"></span>
-                <a w-i18n="passwordForm.back" w-step-prev></a>
+                <a w-i18n="passwordForm.back" w-step-prev ng-click="$ctrl.resetNameAndPassword()"></a>
             </div>
 
             <w-password class="margin-2"


### PR DESCRIPTION
Name and password get reset when the following switching takes place on Restore page:
Name/Password → Seed → Name/Password.