### PR TITLE
CLIENT-1037: Fixed installer paths

### DIFF
--- a/electron/installer.nsh
+++ b/electron/installer.nsh
@@ -1,7 +1,7 @@
 !macro customInstall
-	File "${BUILD_RESOURCES_DIR}/Resources.pri"
-	File "${BUILD_RESOURCES_DIR}/Waves Client.visualelementsmanifest.xml"
-	File "${BUILD_RESOURCES_DIR}/icons/tile*.png"
+	File "${BUILD_RESOURCES_DIR}\Resources.pri"
+	File "${BUILD_RESOURCES_DIR}\Waves Client.visualelementsmanifest.xml"
+	File "${BUILD_RESOURCES_DIR}\icons\tile*.png"
 !macroend
 
 !macro customUnInstall


### PR DESCRIPTION
Changed forward slashed to backward ones and tested that on Mac OS windows build still runs ok.